### PR TITLE
Convert Prefixer to a class

### DIFF
--- a/src/Prefixer.js
+++ b/src/Prefixer.js
@@ -3,62 +3,75 @@ import getBrowserInformation from './getBrowserInformation'
 import caniuseData from './caniuseData'
 import plugins from './Plugins'
 
-let browserinfo = undefined
-let browserProps = undefined
-let lastUserAgent = undefined
-
 const defaultUserAgent = typeof navigator !== 'undefined' ? navigator.userAgent : undefined
 
-/**
- * Processes an object of styles using userAgent specific
- * @param {Object} styles - Styles object that gets prefixed
- * @param {string} userAgent - userAgent to gather prefix information according to caniuse.com
- */
-export default (styles, userAgent = defaultUserAgent) => {
-  if (userAgent && lastUserAgent !== userAgent) {
-    browserinfo = getBrowserInformation(userAgent)
-    let data = caniuseData[browserinfo.browser]
+export default class Prefixer {
+  /**
+   * Instantiante a new prefixer.
+   * @param {string} userAgent - userAgent to gather prefix information according to caniuse.com
+   */
+  constructor(userAgent = defaultUserAgent) {
+    this._userAgent = userAgent
+    this._browserInfo = getBrowserInformation(userAgent)
+
+    this.cssPrefix = this._browserInfo.prefix.CSS
+    this.jsPrefix = this._browserInfo.prefix.inline
+
+    let data = caniuseData[this._browserInfo.browser]
     if (data) {
-      browserProps = Object.keys(data).filter(key => data[key] >= browserinfo.version)
+      this._requiresPrefix = Object.keys(data)
+        .filter(key => data[key] >= this._browserInfo.version)
+        .reduce((result, name) => {
+          result[name] = true
+          return result
+        }, {})
+      this._hasPropsRequiringPrefix = Object.keys(this._requiresPrefix).length > 0
     } else {
+      this._hasPropsRequiringPrefix = false
+
+      // TODO warn only in dev mode
       console.warn('Your userAgent seems to be not supported by inline-style-prefixer. Feel free to open an issue.')
-      return styles
     }
   }
-  //only add prefixes if needed
-  if (browserProps && browserProps.length > 0) {
-    resolveProps(styles)
-  }
-  return styles
-}
 
+  /**
+   * Returns a prefixed version of the style object
+   * @param {Object} styles - Style object that gets prefixed properties added
+   * @returns {Object} - Style object with prefixed properties and valeus
+   */
+  prefix(styles) {
+    // only add prefixes if needed
+    if (!this._hasPropsRequiringPrefix) {
+      return styles
+    }
+
+    styles = assign({}, styles)
+
+    Object.keys(styles).forEach(property => {
+      let value = styles[property]
+      if (value instanceof Object) {
+        // recursively loop through nested style objects
+        styles[property] = this.prefix(value)
+      } else {
+        // add prefixes if needed
+        if (this._requiresPrefix[property]) {
+          styles[this.jsPrefix + caplitalizeString(property)] = value
+          delete styles[property]
+        }
+
+        // resolve plugins
+        plugins.forEach(plugin => {
+          assign(styles, plugin(property, value, this._browserInfo, styles))
+        })
+      }
+    })
+
+    return styles
+  }
+}
 
 /**
  * Capitalizes first letter of a string
  * @param {String} str - str to caplitalize
  */
-const caplitalizeString = (str) => str.charAt(0).toUpperCase() + str.slice(1)
-
-
-/**
- * Adds prefixed properties to a style object
- * @param {Object} styles - Style object that gets prefixed properties added
- */
-export function resolveProps(styles) {
-  Object.keys(styles).forEach(property => {
-    let value = styles[property]
-    if (value instanceof Object) {
-      //recursively loop through nested style objects
-      resolveProps(value)
-    } else {
-      //add prefixes if needed
-      if (browserProps.indexOf(property) > -1) {
-        styles[browserinfo.prefix.inline + caplitalizeString(property)] = value
-        delete styles[property]
-      }
-      //resolve plugins
-      plugins.forEach(plugin => assign(styles, plugin(property, value, browserinfo, styles)))
-    }
-  })
-  return styles
-}
+const caplitalizeString = str => str.charAt(0).toUpperCase() + str.slice(1)

--- a/test/prefixer-test.js
+++ b/test/prefixer-test.js
@@ -23,8 +23,8 @@ describe('Prefixing a property', () => {
       WebkitAppearance: 'test',
       transition: 'test'
     }
-    expect(Prefixer(input, Chrome45)).to.eql(prefixed)
-    expect(Prefixer(input2, Chrome49)).to.eql(input2)
+    expect(new Prefixer(Chrome45).prefix(input)).to.eql(prefixed)
+    expect(new Prefixer(Chrome49).prefix(input2)).to.eql(input2)
   })
 })
 
@@ -37,7 +37,7 @@ describe('Resolving plugins', () => {
     let output = {
       msFlexAlign: 'center'
     }
-    expect(Prefixer(input, MSIE10)).to.eql(output)
+    expect(new Prefixer(MSIE10).prefix(input)).to.eql(output)
   })
   it('should resolve values', () => {
     let input = {
@@ -46,7 +46,7 @@ describe('Resolving plugins', () => {
     let output = {
       display: '-webkit-box'
     }
-    expect(Prefixer(input, Chrome14)).to.eql(output)
+    expect(new Prefixer(Chrome14).prefix(input)).to.eql(output)
   })
 
   it('should resolve alternatives', () => {
@@ -56,6 +56,6 @@ describe('Resolving plugins', () => {
     let output = {
       msFlexPack: 'justify'
     }
-    expect(Prefixer(input, MSIE10)).to.eql(output)
+    expect(new Prefixer(MSIE10).prefix(input)).to.eql(output)
   })
 })


### PR DESCRIPTION
Make it even more stateless. If you want to cache the results of running the UA detection, just cache the prefixer instance. 

- Convert Prefixer to a class with `prefix` method
- Expose `jsPrefix` and `cssPrefix` off the resulting instance
- Don't mutate the passed in style object

New API:

```js
import Prefixer from inline-style-prefixer;

var prefixer = new Prefixer();
var prefixedStyles = prefixer.prefix(styles);