### PR TITLE
[package] Remove the uppercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inline-style-prefixer",
   "version": "0.6.7",
   "description": "Autoprefixer for inline styles using userAgent and caniuse data",
-  "main": "lib/Prefixer.js",
+  "main": "lib/prefixer.js",
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
I feel like the correct file name is in lowercase. I'm wondering what the impact could be.
(Discovered this while investigating for https://github.com/callemall/material-ui/pull/3112, by the way any input are welcome :smile:)