### PR TITLE
Replace OR with AND operator

### DIFF
--- a/modules/plugins/flexboxIE.js
+++ b/modules/plugins/flexboxIE.js
@@ -26,7 +26,7 @@ const properties = Object.keys(alternativeProps).reduce((result, prop) => {
 
 export default function flexboxIE({ property, value, styles, browserInfo: { browser, version }, prefix: { css }, keepUnprefixed }) {
   if (
-    (properties[property] || property === 'display' && value.indexOf('flex') > -1) &&
+    (properties[property] || property === 'display' && typeof value==='string' && value.indexOf('flex') > -1) &&
     (
     (browser === 'ie_mob' || browser === 'ie') && version == 10)
   ) {

--- a/modules/plugins/flexboxOld.js
+++ b/modules/plugins/flexboxOld.js
@@ -26,7 +26,7 @@ const properties = Object.keys(alternativeProps).concat(otherProps).reduce((resu
 
 export default function flexboxOld({ property, value, styles, browserInfo: { browser, version }, prefix: { css }, keepUnprefixed }) {
   if (
-    (properties[property] || property === 'display' && value.indexOf('flex') > -1) &&
+    (properties[property] || property === 'display' && typeof value==='string' && value.indexOf('flex') > -1) &&
     (
     browser === 'firefox' && version < 22 ||
     browser === 'chrome' && version < 21 ||

--- a/test/prefixer-test.js
+++ b/test/prefixer-test.js
@@ -340,6 +340,14 @@ describe('Prefixing display', () => {
       display: 'block'
     })).to.eql({ display: 'block' })
   })
+  it('should not throw if display is null or undefined', () => {
+    expect(new Prefixer({ userAgent: Chrome45 }).prefix({
+      display: null
+    })).to.eql({ display: null })
+    expect(new Prefixer({ userAgent: Chrome45 }).prefix({
+      display: undefined
+    })).to.eql({ display: undefined })
+  })
 })
 
 describe('Using Prefixer.prefixAll', () => {


### PR DESCRIPTION
Changed the operators in flexboxIE.js and flexboxOld.js

The issue with the 'OR' operator is that it will create issues in pages which does not have a `display` property. 

Changing the `OR` operator with `AND` will do the work.

Closes https://github.com/rofrischmann/inline-style-prefixer/issues/70