### PR TITLE
Add node.js >=0.12 requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lib/",
     "dist/"
   ],
+  "engines" : { "node" : ">=0.12" },
   "scripts": {
     "babel": "babel modules/ --out-dir lib",
     "build": "npm run clean && mkdir dist && npm run babel && npm run generate && npm run bundle",


### PR DESCRIPTION
This library uses `Set` which wasn't introduced until `0.11.15`. Since `0.11.15` is a few major version behind and  close to `0.12`, this library should just required `0.12` or later.