### PR TITLE
Fix chromium on linux prefixing that was falling back to prefixall.

### DIFF
--- a/modules/utils/getBrowserInformation.js
+++ b/modules/utils/getBrowserInformation.js
@@ -1,13 +1,13 @@
 import bowser from 'bowser'
 
 const vendorPrefixes = {
-  Webkit: [ 'chrome', 'safari', 'ios', 'android', 'phantom', 'opera', 'webos', 'blackberry', 'bada', 'tizen' ],
+  Webkit: [ 'chrome', 'safari', 'ios', 'android', 'phantom', 'opera', 'webos', 'blackberry', 'bada', 'tizen', 'chromium' ],
   Moz: [ 'firefox', 'seamonkey', 'sailfish' ],
   ms: [ 'msie', 'msedge' ]
 }
 
 const browsers = {
-  chrome: [ [ 'chrome' ] ],
+  chrome: [ [ 'chrome' ], [ 'chromium' ] ],
   safari: [ [ 'safari' ] ],
   firefox: [ [ 'firefox' ] ],
   ie: [ [ 'msie' ] ],


### PR DESCRIPTION
Hello,

I'm using [material-ui](https://github.com/callemall/material-ui) which in turn uses inline-style-prefixer.
I found out the problem I was having is already reported by issue #84.
Following @sunflowerdeath suggestions corrected the issue for me.
This PR has the modification.