### PR TITLE
Fixing browser identification for firefox 48 on old android 4.4.2

### DIFF
--- a/modules/utils/getBrowserInformation.js
+++ b/modules/utils/getBrowserInformation.js
@@ -17,6 +17,28 @@ const browsers = {
   and_uc: [ [ 'android', 'mobile' ], [ 'android', 'tablet' ] ],
   android: [ [ 'android', 'mobile' ], [ 'android', 'tablet' ] ]
 }
+
+const browserByInfo = (info) => {
+  if (info['firefox']) {
+      return 'firefox';
+  }
+  let name = '';
+  Object.keys(browsers).forEach(browser => {
+    browsers[browser].forEach(condition => {
+      let match = 0
+      condition.forEach(single => {
+        if (info[single]) {
+          match += 1
+        }
+      })
+      if (condition.length === match) {
+        name = browser;
+      }
+    })
+  })
+  return name;
+}
+
 /**
  * Uses bowser to get default browser information such as version and name
  * Evaluates bowser info and adds vendorPrefix information
@@ -27,6 +49,7 @@ export default userAgent => {
     return false
   }
   const info = bowser._detect(userAgent)
+
   Object.keys(vendorPrefixes).forEach(prefix => {
     vendorPrefixes[prefix].forEach(browser => {
       if (info[browser]) {
@@ -37,25 +60,13 @@ export default userAgent => {
       }
     })
   })
-  let name = ''
-  Object.keys(browsers).forEach(browser => {
-    browsers[browser].forEach(condition => {
-      let match = 0
-      condition.forEach(single => {
-        if (info[single]) {
-          match += 1
-        }
-      })
-      if (condition.length === match) {
-        name = browser
-      }
-    })
-  })
-  info.browser = name
+
+  info.browser = browserByInfo(info);
 
   // For cordova IOS 8 the version is missing, set truncated osversion to prevent NaN
   info.version = info.version ? parseFloat(info.version) : parseInt(parseFloat(info.osversion), 10)
   info.osversion = parseFloat(info.osversion)
+
 
   // iOS forces all browsers to use Safari under the hood
   // as the Safari version seems to match the iOS version
@@ -65,6 +76,7 @@ export default userAgent => {
     info.version = info.osversion
     info.safari = true
   }
+
 
   // seperate native android chrome
   // https://github.com/rofrischmann/inline-style-prefixer/issues/45

--- a/test/prefixer-test.js
+++ b/test/prefixer-test.js
@@ -6,6 +6,7 @@ const MSEdge12 = 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like 
 const Android4_4_4 = 'Mozilla/5.0 (Linux; Android 4.4.4; One Build/KTU84L.H4) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36'
 const CordovaIOS8_4 = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12H141'
 const Android4_2_2Chrome47 = 'Mozilla/5.0 (Linux; Android 4.2.2; Galaxy Nexus Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36'
+const Android4_2_2Firefox48 = 'Mozilla/5.0 (Android 4.2.2; Mobile; rv:48.0) Gecko/48.0 Firefox/48.0'
 const iOSChrome47 = 'Mozilla/5.0 (iPad; CPU OS 8_4_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) CriOS/47.0.2526.107 Mobile/12H321 Safari/600.1.4'
 const Chrome14 = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/14.0.812.0 Safari/535.1'
 const Chrome22 = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.2 (KHTML, like Gecko) Chrome/22.0.1216.0 Safari/537.2'
@@ -66,6 +67,13 @@ describe('Running on android < 4.4', () => {
     })
     expect(andPrefixer._browserInfo.osversion).to.eql(4.2)
     expect(andPrefixer._browserInfo.version).to.eql(47)
+  })
+  it('Should use firefox version on android 4.2.2', () => {
+        const andPrefixer = new Prefixer({
+          userAgent: Android4_2_2Firefox48
+        })
+        expect(andPrefixer._browserInfo.osversion).to.eql(4.2)
+        expect(andPrefixer._browserInfo.version).to.eql(48)
   })
 })
 describe('Running on iOS', () => {


### PR DESCRIPTION
This pull request fixes issue 
https://github.com/rofrischmann/inline-style-prefixer/issues/95

We should probably find a better way to implement browserByInfo below. It seems like the last matching browser is chosen, however order of keys is not well defined for a map. The tests seem to pass, but the order of Object.keys(browsers) is not guaranteed.

Tell me what you think.