### PR TITLE
Use regex.test(str) instead of str.match(regex)

### DIFF
--- a/modules/dynamic/plugins/gradient.js
+++ b/modules/dynamic/plugins/gradient.js
@@ -13,7 +13,7 @@ export default function gradient(
 ): ?Array<any> | ?any {
   if (
     typeof value === 'string' &&
-      value.match(values) !== null &&
+      values.test(value) &&
       (browserName === 'firefox' && browserVersion < 16 ||
         browserName === 'chrome' && browserVersion < 26 ||
         (browserName === 'safari' || browserName === 'ios_saf') && browserVersion < 7 ||

--- a/modules/static/plugins/gradient.js
+++ b/modules/static/plugins/gradient.js
@@ -5,7 +5,7 @@ const prefixes = ['-webkit-', '-moz-', '']
 const values = /linear-gradient|radial-gradient|repeating-linear-gradient|repeating-radial-gradient/
 
 export default function gradient(property: string, value: any): ?Array<string> {
-  if (typeof value === 'string' && !isPrefixedValue(value) && value.match(values) !== null) {
+  if (typeof value === 'string' && !isPrefixedValue(value) && values.test(value)) {
     return prefixes.map(prefix => prefix + value)
   }
 }

--- a/modules/static/plugins/transition.js
+++ b/modules/static/plugins/transition.js
@@ -62,7 +62,7 @@ export default function transition(
     // if the property is already prefixed
     const webkitOutput = outputValue
       .split(/,(?![^()]*(?:\([^()]*\))?\))/g)
-      .filter(val => val.match(/-moz-|-ms-/) === null)
+      .filter(val => !/-moz-|-ms-/.test(val))
       .join(',')
 
     if (property.indexOf('Webkit') > -1) {
@@ -71,7 +71,7 @@ export default function transition(
 
     const mozOutput = outputValue
       .split(/,(?![^()]*(?:\([^()]*\))?\))/g)
-      .filter(val => val.match(/-webkit-|-ms-/) === null)
+      .filter(val => !/-webkit-|-ms-/.test(val))
       .join(',')
 
     if (property.indexOf('Moz') > -1) {


### PR DESCRIPTION
In all of these places, we really care about a boolean regex match so
we can use the much faster regex.test instead of str.match.

https://jsperf.com/str-match-vs-regex-test/1

At a glance, I see a few more opportunities for performance
improvements (e.g. moving regex declarations up to the module level),
but I'm going to leave them for now.