### PR TITLE
flexBasis fix for IE

### DIFF
--- a/modules/dynamic/plugins/flexboxIE.js
+++ b/modules/dynamic/plugins/flexboxIE.js
@@ -19,7 +19,7 @@ const alternativeProps = {
   order: 'msFlexOrder',
   flexGrow: 'msFlexPositive',
   flexShrink: 'msFlexNegative',
-  flexBasis: 'msPreferredSize'
+  flexBasis: 'msFlexPreferredSize'
 }
 
 export default function flexboxIE(

--- a/modules/static/plugins/flexboxIE.js
+++ b/modules/static/plugins/flexboxIE.js
@@ -13,7 +13,7 @@ const alternativeProps = {
   order: 'msFlexOrder',
   flexGrow: 'msFlexPositive',
   flexShrink: 'msFlexNegative',
-  flexBasis: 'msPreferredSize'
+  flexBasis: 'msFlexPreferredSize'
 }
 
 export default function flexboxIE(property: string, value: any, style: Object): void {


### PR DESCRIPTION
Corrected the -ms prefix for the flexBasis property. See an example of IE interpreting this property below:
<img width="419" alt="28543396-721e1726-7074-11e7-9501-a613cb79c597" src="https://user-images.githubusercontent.com/10523155/28585368-f0c35630-7124-11e7-832f-64f32305b4c2.png">
