### PR TITLE
fix gradient plugin for static prefixer

### DIFF
--- a/modules/static/plugins/gradient.js
+++ b/modules/static/plugins/gradient.js
@@ -1,11 +1,125 @@
 /* @flow */
 import isPrefixedValue from 'css-in-js-utils/lib/isPrefixedValue'
 
-const prefixes = ['-webkit-', '-moz-', '']
+const isDirection = /top|left|right|bottom/gi
+
+const names = [
+  'linear-gradient',
+  'repeating-linear-gradient',
+  'radial-gradient',
+  'repeating-radial-gradient'
+]
+
+// direction to replace
+const directions = {
+  top: 'bottom',
+  left: 'right',
+  bottom: 'top',
+  right: 'left'
+}
+
+const prefixes = ['-webkit-', '-moz-']
 const values = /linear-gradient|radial-gradient|repeating-linear-gradient|repeating-radial-gradient/
+
+/**
+ * covert valStr into deg through full angle.
+ */
+function normalizeAngleUnit(valStr: string, full: number): number {
+  const val = parseFloat(valStr)
+  return val / full * 360
+}
+
+function wrapRange(min: number, max: number, value: number) {
+  var maxLessMin = max - min;
+  return ((value - min) % maxLessMin + maxLessMin) % maxLessMin + min;
+}
+
+/**
+ * normalize angle value.
+ */
+function normalize (value: string): string {
+  if (!value) {
+    return value
+  }
+  return value
+    .trim()
+    .replace(/^([+-]?\d+(?:.\d+)?)grad/, function ($0, $1) {
+      return `${normalizeAngleUnit($1, 400)}deg`
+    })
+    .replace(/^([+-]?\d+(?:.\d+)?)rad/, function ($0, $1) {
+      return `${normalizeAngleUnit($1, 2 * Math.PI)}deg`
+    })
+    .replace(/^([+-]?\d+(?:.\d+)?)turn/, function ($0, $1) {
+      return `${normalizeAngleUnit($1, 1)}deg`
+    })
+    .replace(/^([+-]?\d+(?:.\d+)?)deg/, function ($0, $1) {
+      let val = `${wrapRange(0, 360, parseFloat($1))}deg`
+      switch (val) {
+        case '0deg':
+          val = 'to top'
+          break
+        case '90deg':
+          val = 'to right'
+          break
+        case '180deg':
+          val = 'to bottom'
+          break
+        case '270deg':
+          val = 'to left'
+          break
+      }
+      return val
+    })
+}
+
+/**
+ * convert directions to old version.
+ */
+function convertDirection (value: string): string {
+  return value
+    .replace(/^to\s(top|left|bottom|right)(?:\s+(top|left|bottom|right))?/, function ($0, $1, $2) {
+      const dir2 = $2 && ` ${directions[$2]}` || ''
+      return `${directions[$1]}${dir2}`
+    })
+    .replace(/^([+-]?\d+(?:.\d+)?)deg/, function ($0, $1) {
+      let val = Math.abs(450 - parseFloat($1)) % 360
+      val = parseFloat(val.toFixed(3))
+      return `${val}deg`
+    })
+}
+
+/**
+ * fix radial direction syntax.
+ * e.g.
+ *  farthest-side at 0 50%, white, black
+ *   -> 0 50%, farthest-side, white, black
+ */
+function fixRadial (value: string): string {
+  return value.replace(/^(\S+)\sat\s([^,]+)/, function ($0, $1, $2) {
+    return `${$2}, ${$1}`
+  })
+}
+
+function transformValue (value: string): string {
+  value = normalize(value)
+  value = convertDirection(value)
+  value = fixRadial(value)
+  return value
+}
 
 export default function gradient(property: string, value: any): ?Array<string> {
   if (typeof value === 'string' && !isPrefixedValue(value) && values.test(value)) {
-    return prefixes.map(prefix => prefix + value)
+    // TODO:  support repeating-linear-gradient
+    const insertPrefixFlag = '@@@'
+    const newValue = value.replace(/(linear-gradient|radial-gradient|repeating-linear-gradient|repeating-radial-gradient)\(([^)]+)\)/g,
+      function ($0, $1, $2) {
+        return `${insertPrefixFlag}${$1}(${transformValue($2)})`
+      })
+    const results = prefixes.map(prefix => newValue.replace(
+        new RegExp(insertPrefixFlag, 'g'),
+        prefix
+      ))
+    results.push(value)
+    return results
   }
 }

--- a/modules/static/plugins/gradient.js
+++ b/modules/static/plugins/gradient.js
@@ -109,9 +109,13 @@ function transformValue (value: string): string {
 
 export default function gradient(property: string, value: any): ?Array<string> {
   if (typeof value === 'string' && !isPrefixedValue(value) && values.test(value)) {
-    // TODO:  support repeating-linear-gradient
     const insertPrefixFlag = '@@@'
-    const newValue = value.replace(/(linear-gradient|radial-gradient|repeating-linear-gradient|repeating-radial-gradient)\(([^)]+)\)/g,
+    const reg = new RegExp(
+      `(${values.toString().substr(1).replace(/\/$/, '')})\\\(([^)]+)\\\)`,
+      'g'
+    )
+    const newValue = value.replace(
+      reg,
       function ($0, $1, $2) {
         return `${insertPrefixFlag}${$1}(${transformValue($2)})`
       })

--- a/test/_setup/test-setup.js
+++ b/test/_setup/test-setup.js
@@ -7,6 +7,8 @@ const staticPlugins = require('../../modules/static/plugins')
 
 const generateData = require('../../modules/generator')
 
+const gradientData = require('../data/gradient.json').gradient
+
 const browserList = {
   chrome: 0,
   android: 0,
@@ -39,3 +41,6 @@ const Prefixer = createDynamicPrefixer(
 global.expect = chai.expect
 global.prefixAll = prefixAll
 global.Prefixer = Prefixer
+
+// data for tests.
+global._data = { gradient: gradientData }

--- a/test/data/gradient.json
+++ b/test/data/gradient.json
@@ -1,0 +1,234 @@
+{
+  "gradient": [
+    {
+      "name": "a",
+      "input": {
+        "background": "linear-gradient(350.5deg, white, black), linear-gradient(-130deg, black, white), linear-gradient(45deg, black, white)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(99.5deg, white, black), -webkit-linear-gradient(220deg, black, white), -webkit-linear-gradient(45deg, black, white)",
+          "-moz-linear-gradient(99.5deg, white, black), -moz-linear-gradient(220deg, black, white), -moz-linear-gradient(45deg, black, white)",
+          "linear-gradient(350.5deg, white, black), linear-gradient(-130deg, black, white), linear-gradient(45deg, black, white)"
+        ]
+      }
+    },
+    {
+      "name": "b",
+      "input": {
+        "background-image": "linear-gradient(rgba(0,0,0,1), white), linear-gradient(white, black)"
+      },
+      "output": {
+        "background-image": [
+          "-webkit-linear-gradient(rgba(0,0,0,1), white), -webkit-linear-gradient(white, black)",
+          "-moz-linear-gradient(rgba(0,0,0,1), white), -moz-linear-gradient(white, black)",
+          "linear-gradient(rgba(0,0,0,1), white), linear-gradient(white, black)"
+        ]
+      }
+    },
+    {
+      "name": "strong",
+      "input": {
+        "background": "linear-gradient(to top, transparent, rgba(0, 0, 0, 0.8) 20px, #000 30px, #000) no-repeat"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(bottom, transparent, rgba(0, 0, 0, 0.8) 20px, #000 30px, #000) no-repeat",
+          "-moz-linear-gradient(bottom, transparent, rgba(0, 0, 0, 0.8) 20px, #000 30px, #000) no-repeat",
+          "linear-gradient(to top, transparent, rgba(0, 0, 0, 0.8) 20px, #000 30px, #000) no-repeat"
+        ]
+      }
+    },
+    {
+      "name": "div",
+      "input": {
+        "background-image": "radial-gradient(to left, white, black), repeating-linear-gradient(to bottom right, black, white), repeating-radial-gradient(to top, aqua, red)"
+      },
+      "output": {
+        "background-image": [
+          "-webkit-radial-gradient(right, white, black), -webkit-repeating-linear-gradient(top left, black, white), -webkit-repeating-radial-gradient(bottom, aqua, red)",
+          "-moz-radial-gradient(right, white, black), -moz-repeating-linear-gradient(top left, black, white), -moz-repeating-radial-gradient(bottom, aqua, red)",
+          "radial-gradient(to left, white, black), repeating-linear-gradient(to bottom right, black, white), repeating-radial-gradient(to top, aqua, red)"
+        ]
+      }
+    },
+    {
+      "name": ".radial",
+      "input": {
+        "background": "radial-gradient(ellipse farthest-corner, black, white)"
+      },
+      "output": {
+        "background": [
+          "-webkit-radial-gradient(ellipse farthest-corner, black, white)",
+          "-moz-radial-gradient(ellipse farthest-corner, black, white)",
+          "radial-gradient(ellipse farthest-corner, black, white)"
+        ]
+      }
+    },
+    {
+      "name": ".simple1",
+      "input": {
+        "background": "linear-gradient(black, white)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(black, white)",
+          "-moz-linear-gradient(black, white)",
+          "linear-gradient(black, white)"
+        ]
+      }
+    },
+    {
+      "name": ".simple2",
+      "input": {
+        "background": "linear-gradient(to left, black 0%, rgba(0, 0, 0, 0.5)50%, white 100%)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(right, black 0%, rgba(0, 0, 0, 0.5)50%, white 100%)",
+          "-moz-linear-gradient(right, black 0%, rgba(0, 0, 0, 0.5)50%, white 100%)",
+          "linear-gradient(to left, black 0%, rgba(0, 0, 0, 0.5)50%, white 100%)"
+        ]
+      }
+    },
+    {
+      "name": ".simple3",
+      "input": {
+        "background": "linear-gradient(to left, black 50%, white 100%)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(right, black 50%, white 100%)",
+          "-moz-linear-gradient(right, black 50%, white 100%)",
+          "linear-gradient(to left, black 50%, white 100%)"
+        ]
+      }
+    },
+    {
+      "name": ".simple4",
+      "input": {
+        "background": "linear-gradient(to right top, black, white)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(left bottom, black, white)",
+          "-moz-linear-gradient(left bottom, black, white)",
+          "linear-gradient(to right top, black, white)"
+        ]
+      }
+    },
+    {
+      "name": ".direction",
+      "input": {
+        "background": "linear-gradient(top left, black, rgba(0, 0, 0, 0.5), white)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(top left, black, rgba(0, 0, 0, 0.5), white)",
+          "-moz-linear-gradient(top left, black, rgba(0, 0, 0, 0.5), white)",
+          "linear-gradient(top left, black, rgba(0, 0, 0, 0.5), white)"
+        ]
+      }
+    },
+    {
+      "name": ".silent",
+      "input": {
+        "background": "-webkit-linear-gradient(top left, black, white)"
+      },
+      "output": {
+        "background": "-webkit-linear-gradient(top left, black, white)"
+      }
+    },
+    {
+      "name": ".radial",
+      "input": {
+        "background": "radial-gradient(farthest-side at 0 50%, white, black)"
+      },
+      "output": {
+        "background": [
+          "-webkit-radial-gradient(0 50%, farthest-side, white, black)",
+          "-moz-radial-gradient(0 50%, farthest-side, white, black)",
+          "radial-gradient(farthest-side at 0 50%, white, black)"
+        ]
+      }
+    },
+    {
+      "name": ".px",
+      "input": {
+        "background": "linear-gradient(black 0, white 100px)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(black 0, white 100px)",
+          "-moz-linear-gradient(black 0, white 100px)",
+          "linear-gradient(black 0, white 100px)"
+        ]
+      }
+    },
+    {
+      "name": ".list",
+      "input": {
+        "list-style-image": "linear-gradient(white, black)"
+      },
+      "output": {
+        "list-style-image": [
+          "-webkit-linear-gradient(white, black)",
+          "-moz-linear-gradient(white, black)",
+          "linear-gradient(white, black)"
+        ]
+      }
+    },
+    {
+      "name": ".convert",
+      "input": {
+        "background": "linear-gradient(270deg, white, black)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(right, white, black)",
+          "-moz-linear-gradient(right, white, black)",
+          "linear-gradient(270deg, white, black)"
+        ]
+      }
+    },
+    {
+      "name": ".rad",
+      "input": {
+        "background": "linear-gradient(1rad, white, black)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(32.704deg, white, black)",
+          "-moz-linear-gradient(32.704deg, white, black)",
+          "linear-gradient(1rad, white, black)"
+        ]
+      }
+    },
+    {
+      "name": ".turn",
+      "input": {
+        "background": "linear-gradient(0.3turn, white, black)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(342deg, white, black)",
+          "-moz-linear-gradient(342deg, white, black)",
+          "linear-gradient(0.3turn, white, black)"
+        ]
+      }
+    },
+    {
+      "name": ".norm",
+      "input": {
+        "background": "linear-gradient(-90deg, white, black)"
+      },
+      "output": {
+        "background": [
+          "-webkit-linear-gradient(right, white, black)",
+          "-moz-linear-gradient(right, white, black)",
+          "linear-gradient(-90deg, white, black)"
+        ]
+      }
+    }
+  ]
+}

--- a/test/static/createPrefixer-test.js
+++ b/test/static/createPrefixer-test.js
@@ -115,17 +115,14 @@ describe('Static Prefixer', () => {
       expect(prefixAll(input)).to.eql(output)
     })
 
-    it('should prefix gradients', () => {
-      const input = { background: 'linear-gradient(to bottom right, red, yellow)' }
-      const output = {
-        background: [
-          '-webkit-linear-gradient(to bottom right, red, yellow)',
-          '-moz-linear-gradient(to bottom right, red, yellow)',
-          'linear-gradient(to bottom right, red, yellow)'
-        ]
+    describe('prefix gradients', () => {
+      const ioArr = global._data.gradient
+      for (const io of ioArr) {
+        it ('should pass ' + io.name, () => {
+          expect(prefixAll(io.input)).to.eql(io.output)
+          expect(prefixAll(io.input)).to.eql(io.output)
+        })
       }
-      expect(prefixAll(input)).to.eql(output)
-      expect(prefixAll(input)).to.eql(output)
     })
 
     it('should add all flexbox display types', () => {


### PR DESCRIPTION
I've used the static prefixer for my project, and It works greate for most time right now, since my project is only running on mobile platforms. However the transformed result for gradient is not working, because the old vendor style is not quite the same as the standard writing.

So I found the plugin for gradient is just to add vendor prefixes to the given gradient values. The browser will not accept that, and the showing result is quit opposite for vendors version (See the test cases you'll know what I mean) and the standard version. So I add some converting including the direction change and the angle recalculation, and more test cases too.
