### PR TITLE
Add prefixed properties to the style object before the unprefixed property

### DIFF
--- a/modules/static/createPrefixer.js
+++ b/modules/static/createPrefixer.js
@@ -43,7 +43,7 @@ StaticData
           style[property] = processedValue
         }
 
-        prefixProperty(prefixMap, property, style)
+        style = prefixProperty(prefixMap, property, style)
       }
     }
 

--- a/modules/utils/prefixProperty.js
+++ b/modules/utils/prefixProperty.js
@@ -7,9 +7,20 @@ export default function prefixProperty(
   style: Object
 ): void {
   if (prefixProperties.hasOwnProperty(property)) {
+    const newStyle = {}
     const requiredPrefixes = prefixProperties[property]
-    for (let i = 0, len = requiredPrefixes.length; i < len; ++i) {
-      style[requiredPrefixes[i] + capitalizeString(property)] = style[property]
+    const capitalizedProperty = capitalizeString(property)
+    const keys = Object.keys(style)
+    for (let i = 0; i < keys.length; i++) {
+      const styleProperty = keys[i]
+      if (styleProperty === property) {
+        for (let j = 0; j < requiredPrefixes.length; j++) {
+          newStyle[requiredPrefixes[j] + capitalizedProperty] = style[property]
+        }
+      }
+      newStyle[styleProperty] = style[styleProperty]
     }
+    return newStyle
   }
+  return style
 }


### PR DESCRIPTION
This is a patch to add prefixed properties to the returned style object before the unprefixed property. The test suite passes without modification. Fixes #147.

### Reason

It's the [recommended practice](https://css-tricks.com/ordering-css3-properties/) and was the 2.x behavior. By adding prefixed properties after the unprefixed properties, some browsers demonstrate unexpected behavior. It's preferable for them to come before the unprefixed property.

One common argument against worrying about this is that the traversal order of object properties was not guaranteed anyway (despite most engines implementing it the same way), but [that is no longer the case as of ES6](http://2ality.com/2015/10/property-traversal-order-es6.html) – it is now defined in the spec.

### Benchmarks

I added new `master` test cases to the `benchmark` app to test this out; it ran the equivalent functions directly from the repo (after being built with Babel). This mostly affects the `static` tests, so pay attention to those.

#### Baseline, current master WITHOUT this patch:

```
> @ bench:dynamic /Users/brianbeck/Projects/inline-style-prefixer/benchmark
> babel-node dynamic


Running dynamic test.
  5 tests completed.

  2.0.5  x  6,804 ops/sec ±0.70% (86 runs sampled)
  3.0.0  x 23,966 ops/sec ±1.07% (86 runs sampled)
  3.0.1  x 24,674 ops/sec ±0.54% (85 runs sampled)
  3.0.2  x 24,535 ops/sec ±1.25% (86 runs sampled)
  master x 24,034 ops/sec ±0.60% (89 runs sampled)

Fastest is: 3.0.1,3.0.2

Improvement: 0.98x faster

> @ bench:static /Users/brianbeck/Projects/inline-style-prefixer/benchmark
> babel-node static


Running static test.
  5 tests completed.

  2.0.5  x  6,188 ops/sec ±1.49% (86 runs sampled)
  3.0.0  x 30,512 ops/sec ±2.62% (85 runs sampled)
  3.0.1  x 25,466 ops/sec ±1.68% (88 runs sampled)
  3.0.2  x 32,458 ops/sec ±1.87% (85 runs sampled)
  master x 31,793 ops/sec ±1.94% (84 runs sampled)

Fastest is: 3.0.2

Improvement: 0.98x faster
```

#### WITH this patch applied:

```
> @ bench:dynamic /Users/brianbeck/Projects/inline-style-prefixer/benchmark
> babel-node dynamic


Running dynamic test.
  5 tests completed.

  2.0.5           x  6,685 ops/sec ±0.75% (88 runs sampled)
  3.0.0           x 22,835 ops/sec ±1.88% (87 runs sampled)
  3.0.1           x 23,825 ops/sec ±0.77% (86 runs sampled)
  3.0.2           x 23,740 ops/sec ±0.89% (83 runs sampled)
  master w/ patch x 23,955 ops/sec ±0.97% (88 runs sampled)

Fastest is: master w/ patch,3.0.1,3.0.2

Improvement: 1.01x faster

> @ bench:static /Users/brianbeck/Projects/inline-style-prefixer/benchmark
> babel-node static


Running static test.
  5 tests completed.

  2.0.5           x  6,163 ops/sec ±0.81% (85 runs sampled)
  3.0.0           x 31,123 ops/sec ±2.79% (84 runs sampled)
  3.0.1           x 25,803 ops/sec ±1.61% (86 runs sampled)
  3.0.2           x 30,986 ops/sec ±2.84% (86 runs sampled)
  master w/ patch x 27,611 ops/sec ±1.63% (87 runs sampled)

Fastest is: 3.0.0,3.0.2

Improvement: 0.89x faster
```

A tiny bit slower, but still way ahead of 2.x perf, and roughly equivalent to 3.0.1.