### PR TITLE
Fix LG webOS feature support detection

### DIFF
--- a/modules/utils/getBrowserInformation.js
+++ b/modules/utils/getBrowserInformation.js
@@ -66,6 +66,8 @@ export default function getBrowserInformation(
 
   if (browserInfo.yandexbrowser) {
     browserInfo = bowser._detect(userAgent.replace(/YaBrowser\/[0-9.]*/, ''))
+  } else if (browserInfo.webos && browserInfo.blink) {
+    browserInfo = bowser._detect(userAgent.replace('Web0S', ''));
   }
 
   for (const browser in prefixByBrowser) {


### PR DESCRIPTION
Fixes https://github.com/rofrischmann/inline-style-prefixer/issues/160

When blink-based LG webOS is detected, re-execute the detection function with the `Web0S` token. Similar to the YaBrowser, this allows `bowser` to resolve to Chromium release version/details and allow for targeted feature detection by correspond Chrome version.