### PR TITLE
Expand shorthand flex syntax for flexbox for IE

### DIFF
--- a/modules/__tests__/createPrefixer-test.js
+++ b/modules/__tests__/createPrefixer-test.js
@@ -350,5 +350,73 @@ describe('Static Prefixer', () => {
       expect(prefix(input)).toEqual(output)
       expect(prefix(input)).toEqual(output)
     })
+
+    describe('flexboxIE shorthand expansions', () => {
+      it('should expand basic values', () => {
+        const input = { flex: 'auto' }
+        const output = {
+          flex: 'auto',
+          MozFlex: 'auto',
+          msFlex: '1 1 auto',
+          WebkitFlex: 'auto',
+        }
+        expect(prefix(input)).toEqual(output)
+      })
+
+      it('should expand singular flex-grow', () => {
+        const input = { flex: '1' }
+        const output = {
+          flex: '1',
+          MozFlex: '1',
+          msFlex: '1 1 0%',
+          WebkitFlex: '1',
+        }
+        expect(prefix(input)).toEqual(output)
+      })
+
+      it('should expand single united values', () => {
+        const input = { flex: '1px' }
+        const output = {
+          flex: '1px',
+          MozFlex: '1px',
+          msFlex: '1 1 1px',
+          WebkitFlex: '1px',
+        }
+        expect(prefix(input)).toEqual(output)
+      })
+
+      it('should expand flex-grow + flex-shrink', () => {
+        const input = { flex: '1 3' }
+        const output = {
+          flex: '1 3',
+          MozFlex: '1 3',
+          msFlex: '1 3 0%',
+          WebkitFlex: '1 3',
+        }
+        expect(prefix(input)).toEqual(output)
+      })
+
+      it('should pass through 3 values', () => {
+        const input = { flex: '2 2 10%' }
+        const output = {
+          flex: '2 2 10%',
+          MozFlex: '2 2 10%',
+          msFlex: '2 2 10%',
+          WebkitFlex: '2 2 10%',
+        }
+        expect(prefix(input)).toEqual(output)
+      })
+
+      it('should expand flex-grow + flex-basis', () => {
+        const input = { flex: '0 30px' }
+        const output = {
+          flex: '0 30px',
+          MozFlex: '0 30px',
+          msFlex: '0 1 30px',
+          WebkitFlex: '0 30px',
+        }
+        expect(prefix(input)).toEqual(output)
+      })
+    })
   })
 })

--- a/modules/__tests__/createPrefixer-test.js
+++ b/modules/__tests__/createPrefixer-test.js
@@ -364,12 +364,12 @@ describe('Static Prefixer', () => {
       })
 
       it('should expand singular flex-grow', () => {
-        const input = { flex: '1' }
+        const input = { flex: '1.1' }
         const output = {
-          flex: '1',
-          MozFlex: '1',
-          msFlex: '1 1 0%',
-          WebkitFlex: '1',
+          flex: '1.1',
+          MozFlex: '1.1',
+          msFlex: '1.1 1 0%',
+          WebkitFlex: '1.1',
         }
         expect(prefix(input)).toEqual(output)
       })

--- a/modules/plugins/flexboxIE.js
+++ b/modules/plugins/flexboxIE.js
@@ -15,6 +15,15 @@ const alternativeProps = {
   flexShrink: 'msFlexNegative',
   flexBasis: 'msFlexPreferredSize',
 }
+// Full expanded syntax is flex-grow | flex-shrink | flex-basis.
+const flexShorthandMappings = {
+  auto: '1 1 auto',
+  inherit: 'inherit',
+  initial: '0 1 auto',
+  none: '0 0 auto',
+  unset: 'unset',
+}
+const isPositiveNumber = /^\d*[1-9]\d*$/
 
 export default function flexboxIE(
   property: string,
@@ -23,5 +32,42 @@ export default function flexboxIE(
 ): void {
   if (alternativeProps.hasOwnProperty(property)) {
     style[alternativeProps[property]] = alternativeValues[value] || value
+  }
+  if (property === 'flex') {
+    // For certain values we can do straight mappings based on the spec
+    // for the expansions.
+    if (flexShorthandMappings.hasOwnProperty(value)) {
+      style.msFlex = flexShorthandMappings[value]
+      return
+    }
+    // Here we have no direct mapping, so we favor looking for a
+    // unitless positive number as that will be the most common use-case.
+    if (isPositiveNumber.test(value)) {
+      style.msFlex = `${value} 1 0%`
+      return
+    }
+
+    // The next thing we can look for is if there are multiple values.
+    const flexValues = value.split(/\s/)
+    // If we only have a single value that wasn't a positive unitless
+    // or a pre-mapped value, then we can assume it is a unit value.
+    switch (flexValues.length) {
+      case 1:
+        style.msFlex = `1 1 ${value}`
+        return
+      case 2:
+        // If we have 2 units, then we expect that the first will
+        // always be a unitless number and represents flex-grow.
+        // The second unit will represent flex-shrink for a unitless
+        // value, or flex-basis otherwise.
+        if (isPositiveNumber.test(flexValues[1])) {
+          style.msFlex = `${flexValues[0]} ${flexValues[1]} 0%`
+        } else {
+          style.msFlex = `${flexValues[0]} 1 ${flexValues[1]}`
+        }
+        return
+      default:
+        style.msFlex = value
+    }
   }
 }

--- a/modules/plugins/flexboxIE.js
+++ b/modules/plugins/flexboxIE.js
@@ -23,20 +23,20 @@ const flexShorthandMappings = {
   none: '0 0 auto',
   unset: 'unset',
 }
-const isPositiveNumber = /^\d*[1-9]\d*$/
+const isPositiveNumber = /^\d+(\.\d+)?$/
 
 export default function flexboxIE(
   property: string,
   value: any,
   style: Object
 ): void {
-  if (alternativeProps.hasOwnProperty(property)) {
+  if (Object.prototype.hasOwnProperty.call(alternativeProps, property)) {
     style[alternativeProps[property]] = alternativeValues[value] || value
   }
   if (property === 'flex') {
     // For certain values we can do straight mappings based on the spec
     // for the expansions.
-    if (flexShorthandMappings.hasOwnProperty(value)) {
+    if (Object.prototype.hasOwnProperty.call(flexShorthandMappings, value)) {
       style.msFlex = flexShorthandMappings[value]
       return
     }

--- a/modules/plugins/flexboxIE.js
+++ b/modules/plugins/flexboxIE.js
@@ -23,7 +23,7 @@ const flexShorthandMappings = {
   none: '0 0 auto',
   unset: 'unset',
 }
-const isPositiveNumber = /^\d+(\.\d+)?$/
+const isUnitlessNumber = /^\d+(\.\d+)?$/
 
 export default function flexboxIE(
   property: string,
@@ -42,7 +42,7 @@ export default function flexboxIE(
     }
     // Here we have no direct mapping, so we favor looking for a
     // unitless positive number as that will be the most common use-case.
-    if (isPositiveNumber.test(value)) {
+    if (isUnitlessNumber.test(value)) {
       style.msFlex = `${value} 1 0%`
       return
     }
@@ -60,7 +60,7 @@ export default function flexboxIE(
         // always be a unitless number and represents flex-grow.
         // The second unit will represent flex-shrink for a unitless
         // value, or flex-basis otherwise.
-        if (isPositiveNumber.test(flexValues[1])) {
+        if (isUnitlessNumber.test(flexValues[1])) {
           style.msFlex = `${flexValues[0]} ${flexValues[1]} 0%`
         } else {
           style.msFlex = `${flexValues[0]} 1 ${flexValues[1]}`


### PR DESCRIPTION
Fixes https://github.com/rofrischmann/inline-style-prefixer/issues/165. This logic is based off of the documentation at https://developer.mozilla.org/en-US/docs/Web/CSS/flex, and some of the expected test values are from pasting some sample values into dev tools and seeing the computed results as a sanity check.

I tried to make this reasonable, the flex specs are not overly complex but can get a bit interesting in the shorthand syntax with unitless and united values. Please let me know if you think this is a reasonable approach.

