### PR TITLE
Expose generateFile as named export from generator module

### DIFF
--- a/modules/generator/index.js
+++ b/modules/generator/index.js
@@ -9,7 +9,11 @@ function generateImportString(plugin, compatibility) {
   return `import ${plugin} from 'inline-style-prefixer/lib/plugins/${plugin}'`
 }
 
-function generateFile(prefixMap, pluginList, compatibility) {
+export function generateFile(
+  prefixMap: Object,
+  pluginList: Array<string>,
+  compatibility?: boolean
+) {
   const pluginImports = pluginList
     .map(plugin => generateImportString(plugin, compatibility))
     .join('\n')


### PR DESCRIPTION
It's possible (and appealing) to use Webpack's [`val-loader`](https://github.com/webpack-contrib/val-loader) to generate the legacy browser `prefixData` module on the fly at compilation time; however, this requires the ability to generate the code synchronously and capture it as a string.

We can enable this by merely exposing the `generateFile` method as a named export from the `generator` module.